### PR TITLE
Add 2019 uk party colours

### DIFF
--- a/index.html
+++ b/index.html
@@ -926,6 +926,81 @@
         </div>
         
         <div class="palette">
+            <h2 id="ukPoliticalParties_2019"><a href="#ukPoliticalParties_2019">#</a>ukPoliticalParties_2019</h2>
+        
+            <div class="swatch-container">
+                <b>conservative:</b><br>#6da8e1
+                <div class="swatch" style="background:#6da8e1">&nbsp;</div>
+            </div>
+        
+            <div class="swatch-container">
+                <b>labour:</b><br>#e25050
+                <div class="swatch" style="background:#e25050">&nbsp;</div>
+            </div>
+        
+            <div class="swatch-container">
+                <b>liberal democrats:</b><br>#f0a330
+                <div class="swatch" style="background:#f0a330">&nbsp;</div>
+            </div>
+        
+            <div class="swatch-container">
+                <b>ukip:</b><br>#ca6dbf
+                <div class="swatch" style="background:#ca6dbf">&nbsp;</div>
+            </div>
+        
+            <div class="swatch-container">
+                <b>green:</b><br>#65a68c
+                <div class="swatch" style="background:#65a68c">&nbsp;</div>
+            </div>
+        
+            <div class="swatch-container">
+                <b>snp:</b><br>#f2d92d
+                <div class="swatch" style="background:#f2d92d">&nbsp;</div>
+            </div>
+        
+            <div class="swatch-container">
+                <b>dup:</b><br>#827996
+                <div class="swatch" style="background:#827996">&nbsp;</div>
+            </div>
+        
+            <div class="swatch-container">
+                <b>sf:</b><br>#99bf70
+                <div class="swatch" style="background:#99bf70">&nbsp;</div>
+            </div>
+        
+            <div class="swatch-container">
+                <b>pc:</b><br>#99d2d0
+                <div class="swatch" style="background:#99d2d0">&nbsp;</div>
+            </div>
+        
+            <div class="swatch-container">
+                <b>alliance:</b><br>#ffc660
+                <div class="swatch" style="background:#ffc660">&nbsp;</div>
+            </div>
+        
+            <div class="swatch-container">
+                <b>independent:</b><br>#CEC6B9
+                <div class="swatch" style="background:#CEC6B9">&nbsp;</div>
+            </div>
+        
+            <div class="swatch-container">
+                <b>other:</b><br>#CEC6B9
+                <div class="swatch" style="background:#CEC6B9">&nbsp;</div>
+            </div>
+        
+            <div class="swatch-container">
+                <b>sdlp:</b><br>#bed676
+                <div class="swatch" style="background:#bed676">&nbsp;</div>
+            </div>
+        
+            <div class="swatch-container">
+                <b>uup:</b><br>#6da8e1
+                <div class="swatch" style="background:#6da8e1">&nbsp;</div>
+            </div>
+        
+        </div>
+        
+        <div class="palette">
         <h2 id="ukPoliticalParties"><a href="#ukPoliticalParties">#</a>ukPoliticalParties</h2>
             
             <div class="swatch-container">

--- a/index.html
+++ b/index.html
@@ -929,73 +929,83 @@
             <h2 id="ukPoliticalParties_2019"><a href="#ukPoliticalParties_2019">#</a>ukPoliticalParties_2019</h2>
         
             <div class="swatch-container">
-                <b>conservative:</b><br>#6da8e1
-                <div class="swatch" style="background:#6da8e1">&nbsp;</div>
+                <b>Conservative:</b><br>#149ADB
+                <div class="swatch" style="background:#149ADB">&nbsp;</div>
             </div>
         
             <div class="swatch-container">
-                <b>labour:</b><br>#e25050
-                <div class="swatch" style="background:#e25050">&nbsp;</div>
+                <b>Labour:</b><br>#CF4D3C
+                <div class="swatch" style="background:#CF4D3C">&nbsp;</div>
             </div>
         
             <div class="swatch-container">
-                <b>liberal democrats:</b><br>#f0a330
-                <div class="swatch" style="background:#f0a330">&nbsp;</div>
+                <b>Liberal Democrats:</b><br>#f09000
+                <div class="swatch" style="background:#f09000">&nbsp;</div>
             </div>
         
             <div class="swatch-container">
-                <b>ukip:</b><br>#ca6dbf
-                <div class="swatch" style="background:#ca6dbf">&nbsp;</div>
+                <b>UKIP:</b><br>#7200AB
+                <div class="swatch" style="background:#7200AB">&nbsp;</div>
             </div>
         
             <div class="swatch-container">
-                <b>green:</b><br>#65a68c
-                <div class="swatch" style="background:#65a68c">&nbsp;</div>
+                <b>Green:</b><br>#8DEB9D
+                <div class="swatch" style="background:#8DEB9D">&nbsp;</div>
             </div>
         
             <div class="swatch-container">
-                <b>snp:</b><br>#f2d92d
-                <div class="swatch" style="background:#f2d92d">&nbsp;</div>
+                <b>SNP:</b><br>#FFDF00
+                <div class="swatch" style="background:#FFDF00">&nbsp;</div>
             </div>
         
             <div class="swatch-container">
-                <b>dup:</b><br>#827996
-                <div class="swatch" style="background:#827996">&nbsp;</div>
+                <b>DUP:</b><br>#210066
+                <div class="swatch" style="background:#210066">&nbsp;</div>
             </div>
         
             <div class="swatch-container">
-                <b>sf:</b><br>#99bf70
-                <div class="swatch" style="background:#99bf70">&nbsp;</div>
+                <b>Sinn Fin:</b><br>#006643
+                <div class="swatch" style="background:#006643">&nbsp;</div>
             </div>
         
             <div class="swatch-container">
-                <b>pc:</b><br>#99d2d0
+                <b>Plaid Cymru:</b><br>#99d2d0
                 <div class="swatch" style="background:#99d2d0">&nbsp;</div>
             </div>
         
             <div class="swatch-container">
-                <b>alliance:</b><br>#ffc660
-                <div class="swatch" style="background:#ffc660">&nbsp;</div>
+                <b>Independent group for Change:</b><br>#ffDE18
+                <div class="swatch" style="background:#ffDE18">&nbsp;</div>
             </div>
         
             <div class="swatch-container">
-                <b>independent:</b><br>#CEC6B9
-                <div class="swatch" style="background:#CEC6B9">&nbsp;</div>
+                <b>Independent/Other:</b><br>#D9CACE
+                <div class="swatch" style="background:#D9CACE">&nbsp;</div>
             </div>
         
             <div class="swatch-container">
-                <b>other:</b><br>#CEC6B9
-                <div class="swatch" style="background:#CEC6B9">&nbsp;</div>
+                <b>The Speaker:</b><br>#FFFFFF
+                <div class="swatch" style="background:#FFFFFF">&nbsp;</div>
             </div>
         
             <div class="swatch-container">
-                <b>sdlp:</b><br>#bed676
-                <div class="swatch" style="background:#bed676">&nbsp;</div>
+                <b>SDLP:</b><br>#5ba373
+                <div class="swatch" style="background:#5ba373">&nbsp;</div>
             </div>
         
             <div class="swatch-container">
-                <b>uup:</b><br>#6da8e1
-                <div class="swatch" style="background:#6da8e1">&nbsp;</div>
+                <b>UUP:</b><br>#3F67CC
+                <div class="swatch" style="background:#3F67CC">&nbsp;</div>
+            </div>
+
+            <div class="swatch-container">
+                <b>Brexit:</b><br>#80CFD6
+                <div class="swatch" style="background:#80CFD6">&nbsp;</div>
+            </div>
+
+            <div class="swatch-container">
+                <b>Change:</b><br>#FC8B9D
+                <div class="swatch" style="background:#FC8B9D">&nbsp;</div>
             </div>
         
         </div>


### PR DESCRIPTION
I’ve added the UK political colours that we used in the 2019 election. I have also used the correct party names ie 'Labour' with a cap L and Sinn Fin rather than sf. I’ve done this because it will mean that the chart doesn’t have to be edited as much at the point of production with regard to labelling lines etc. But this will mean that column headings in datasets will have to follow the same protocol. I suspect this will cause objections, so its more a conversation starter as to how we go about this for the production efficiency